### PR TITLE
New BQL keywords and bug fixes

### DIFF
--- a/app/components/schema-table.js
+++ b/app/components/schema-table.js
@@ -24,8 +24,11 @@ export default class SchemaTableComponent extends PaginatedTable {
     this.table = Table.create({ columns: this.columns });
     if (!this.args.isNested) {
       this.sortBy('name', 'ascending');
+      this.addPages(2);
+    } else {
+      // Add everything if nested
+      this.addRows(0, this.numberOfRows);
     }
-    this.addPages(2);
   }
 
   static fieldsToRows(fields) {

--- a/app/utils/builder-adapter.js
+++ b/app/utils/builder-adapter.js
@@ -447,12 +447,18 @@ export function addQueryBuilderRules(element, rules, bql) {
  * @param {function} validateHook The hook to invoke for validation when something changes in the QueryBuilder.
  */
 export function addQueryBuilderHooks(element, context, dirtyHook, validateHook) {
-  element.on('rulesChanged.queryBuilder', bind(context, dirtyHook));
-  let event = [
+  let subFieldChanged = 'afterUpdateRuleSubfield.queryBuilder';
+  let dirtyEvents = [
+    'rulesChanged.queryBuilder',
+    subFieldChanged
+  ];
+  element.on(dirtyEvents.join(' '), bind(context, dirtyHook));
+
+  let validateEvents = [
     'afterUpdateRuleFilter.queryBuilder',
     'afterUpdateRuleOperator.queryBuilder',
-    'afterUpdateRuleSubfield.queryBuilder',
+    subFieldChanged,
     'afterUpdateRuleValue.queryBuilder'
   ];
-  element.on(event.join(' '), bind(context, validateHook));
+  element.on(validateEvents.join(' '), bind(context, validateHook));
 }

--- a/app/utils/codemirror-adapter.js
+++ b/app/utils/codemirror-adapter.js
@@ -75,6 +75,6 @@ function getConfiguration(columns) {
       }
     },
     autoCloseBrackets: true,
-    matchBrackets: true,
+    matchBrackets: true
   };
 }

--- a/app/utils/codemirror-adapter.js
+++ b/app/utils/codemirror-adapter.js
@@ -28,12 +28,13 @@ export function defineBQL() {
     name: 'sql',
     keywords: set('select as cast count distinct sum min max avg from where if and or not xor is all any true false ' +
                   'null group by having order asc desc limit every first time record linear region manual stream '  +
-                  'windowing tumbling quantile freq cumfreq top sizeis sizeof filter rlike containskey containsvalue'),
+                  'windowing tumbling quantile freq cumfreq top sizeis sizeof filter rlike containskey containsvalue ' +
+                  'lateral view outer explode trim abs between substring unixtimestamp'),
     builtin: set('string boolean integer long float double map list'),
     atoms: set('false true null'),
     operatorChars: /^[*+\-/%<>!=&|^]/,
     dateSQL: { },
-    support: set('zerolessFloat doubleQuote commentHash commentSlashSlash')
+    support: set('ODBCdotTable zerolessFloat doubleQuote commentHash commentSlashSlash')
   });
 }
 
@@ -74,6 +75,6 @@ function getConfiguration(columns) {
       }
     },
     autoCloseBrackets: true,
-    matchBrackets: true
+    matchBrackets: true,
   };
 }

--- a/app/utils/codemirror-adapter.js
+++ b/app/utils/codemirror-adapter.js
@@ -29,7 +29,7 @@ export function defineBQL() {
     keywords: set('select as cast count distinct sum min max avg from where if and or not xor is all any true false ' +
                   'null group by having order asc desc limit every first time record linear region manual stream '  +
                   'windowing tumbling quantile freq cumfreq top sizeis sizeof filter rlike containskey containsvalue ' +
-                  'lateral view outer explode trim abs between substring unixtimestamp'),
+                  'lateral view outer explode trim abs between substr substring unixtimestamp'),
     builtin: set('string boolean integer long float double map list'),
     atoms: set('false true null'),
     operatorChars: /^[*+\-/%<>!=&|^]/,

--- a/config/env-settings.json
+++ b/config/env-settings.json
@@ -1,13 +1,13 @@
 {
   "default": {
-    "queryHost": "https://foo.bar.com:4443",
-    "queryNamespace": "api/bullet/queries",
+    "queryHost": "https://bullet-api.data.yahoo.com:4443",
+    "queryNamespace": "bullet/api/queries",
     "queryPath": "ws-query",
     "validationPath": "validate-query",
     "queryStompRequestChannel": "/server/request",
     "queryStompResponseChannel": "/client/response",
-    "schemaHost": "https://foo.bar.com:4443",
-    "schemaNamespace": "api/bullet",
+    "schemaHost": "https://bullet-api.data.yahoo.com:4443",
+    "schemaNamespace": "bullet/api",
     "helpLinks": [
       {
         "name": "Tutorials",

--- a/config/env-settings.json
+++ b/config/env-settings.json
@@ -1,13 +1,13 @@
 {
   "default": {
-    "queryHost": "https://bullet-api.data.yahoo.com:4443",
-    "queryNamespace": "bullet/api/queries",
+    "queryHost": "https://foo.bar.com:4443",
+    "queryNamespace": "api/bullet/queries",
     "queryPath": "ws-query",
     "validationPath": "validate-query",
     "queryStompRequestChannel": "/server/request",
     "queryStompResponseChannel": "/client/response",
-    "schemaHost": "https://bullet-api.data.yahoo.com:4443",
-    "schemaNamespace": "bullet/api",
+    "schemaHost": "https://foo.bar.com:4443",
+    "schemaNamespace": "api/bullet",
     "helpLinks": [
       {
         "name": "Tutorials",


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

- Makes schema table load all expanded rows on open
- Fixes the dot autocomplete bug that did not respect the word before the dot in the autocomplete list
- Fixes the subfield in the querybuilder not causing dirty flag marking and therefore, losing subfield changes
- Supports LATERAL VIEW OUTER EXPLODE ABS TRIM BETWEEN SUBSTRING UNIXTIMESTAMP keywords in BQL